### PR TITLE
Separating history object from reducer

### DIFF
--- a/redux-example/index.js
+++ b/redux-example/index.js
@@ -12,8 +12,6 @@ const NAVIGATE = 'NAVIGATE'
 
 const initialState = {
   router: {
-    location: history.location,
-    action: history.action
   }
 }
 
@@ -47,11 +45,14 @@ const App = connect((state) => {
   }
 
   render() {
+    const location = this.props.location || history.location;
+    const action = this.props.action || history.action;
+
     return (
       <Router
         history={history}
-        location={this.props.location}
-        action={this.props.action}
+        location={location}
+        action={action}
         onChange={(location, action) => {
           // you must always dispatch a `SYNC` action,
           // because, guess what? you can't actual control the browser history!


### PR DESCRIPTION
When you use this example to put it in a real world redux app you might want to split reducer and router into separate files. I think the best way to deal with the history object is leave it out of the reducer and check at the render method if `location` and `action` is undefined.

Another option would be to put the history object in the store as well (does not feel very reduxish) or to instantiate it twice (yikes).